### PR TITLE
Fix retry attempt to resolve all rules

### DIFF
--- a/python/tk_multi_data_validation/api/manager.py
+++ b/python/tk_multi_data_validation/api/manager.py
@@ -369,10 +369,12 @@ class ValidationManager(object):
                     # Update the previous errors to the current set
                     prev_errors = set(self.errors)
 
-                    # Attempt to resolve again
+                    # Attempt to resolve again. This time we need to fetch dependencies since
+                    # we are only passing the errors and not all dependencies may be present
+                    # in the errors list.
                     self.resolve_rules(
                         self.errors.values(),
-                        fetch_dependencies=False,
+                        fetch_dependencies=True,
                         emit_signals=False,
                     )
                     # Check for errors


### PR DESCRIPTION
* Sometimes executing a fix for a rule may introduce new errors to rules that have already been "fixed". Dependencies can be set up to avoid this issue but we will also try to be smart and attempt to retry to resolve. In the event that we retry to resolve, we need to fetch dependencies since this time around we do not have all rules available, only the error rules